### PR TITLE
Fix: The application failed to increase the file descriptor limit (ulimit), which could lead to 'Too many open files' errors under load. This indicates a container environment configuration issue that may cause runtime failures.

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -16,7 +16,8 @@ steps:
     '--image', '${_IMAGE}',
     '--region', 'us-central1',
     '--platform', 'managed',
-    '--allow-unauthenticated'
+    '--allow-unauthenticated',
+    '--execution-environment', 'gen2'
   ]
 
 - name: 'python:3.9-slim'


### PR DESCRIPTION
This PR fixes the following issue: The application failed to increase the file descriptor limit (ulimit), which could lead to 'Too many open files' errors under load. This indicates a container environment configuration issue that may cause runtime failures.

**Relevant Log Entries:**
```
TextEntry(log_name='projects/globalbiting-dev/logs/run.googleapis.com%2Fstdout', ..., payload='\x1b[1;36m(APIServer pid=1)\x1b[0;0m WARNING 10-04 21:47:22 [__init__.py:2762] Found ulimit of 25000 and failed to automatically increase with error current limit exceeds maximum limit. This can cause fd limit errors like `OSError: [Errno 24] Too many open files`. Consider increasing with ulimit -n')
```