### PR TITLE
Fix: The PyTorch distributed communication library (c10d) logs warnings about being unable to retrieve the client socket hostname. This may indicate a networking or library-level misconfiguration that could cause instability or performance issues, even in a single-node environment.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,13 @@ ENV HF_HOME=/model-cache
 
 ENV HF_HUB_OFFLINE=1
 
-ENTRYPOINT python3 -m vllm.entrypoints.openai.api_server \
+# Fix for c10d warning: "The hostname of the client socket cannot be retrieved."
+# This occurs in container environments where reverse DNS lookup for the container's IP fails.
+# Adding the container's hostname to /etc/hosts pointing to localhost resolves this.
+# The 'exec' command is used to ensure the python process replaces the shell,
+# allowing it to receive signals correctly for graceful shutdown.
+ENTRYPOINT echo "127.0.0.1 $(hostname)" >> /etc/hosts && \
+    exec python3 -m vllm.entrypoints.openai.api_server \
     --port ${PORT:-8000} \
     --model ${MODEL_NAME:-google/gemma-3-1b-it} \
     ${MAX_MODEL_LEN:+--max-model-len "$MAX_MODEL_LEN"}


### PR DESCRIPTION
This PR fixes the following issue: The PyTorch distributed communication library (c10d) logs warnings about being unable to retrieve the client socket hostname. This may indicate a networking or library-level misconfiguration that could cause instability or performance issues, even in a single-node environment.

**Relevant Log Entries:**
```
[W1004 21:48:15.867586534 socket.cpp:200] [c10d] The hostname of the client socket cannot be retrieved. err=-3
[W1004 21:48:15.869624466 socket.cpp:200] [c10d] The hostname of the client socket cannot be retrieved. err=-3
[W1004 22:05:37.442081355 socket.cpp:200] [c10d] The hostname of the client socket cannot be retrieved. err=-3
[W1004 22:05:37.444274762 socket.cpp:200] [c10d] The hostname of the client socket cannot be retrieved. err=-3
```