### PR TITLE
feat: Set TORCH_CUDA_ARCH_LIST for NVIDIA T4 GPUs

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,24 @@
+# Hugging Face Token (required for downloading models during build)
+HF_TOKEN=your_hugging_face_token_here
+
+# Model Configuration
+MODEL_NAME=google/gemma-3-1b-it
+HF_HOME=/model-cache
+
+# Server Configuration
+PORT=8000
+# MAX_MODEL_LEN=2048  # Optional: Set maximum model length
+
+# CUDA Architecture Configuration
+# This setting is optimized for Google Cloud Run which uses NVIDIA T4 GPUs
+# NVIDIA T4 has compute capability 7.5
+# Setting this reduces compilation time by avoiding compilation for all GPU architectures
+TORCH_CUDA_ARCH_LIST=7.5
+
+# Common GPU compute capabilities for reference:
+# - NVIDIA T4 (Cloud Run): 7.5
+# - NVIDIA V100: 7.0
+# - NVIDIA A100: 8.0
+# - NVIDIA H100: 9.0
+# - RTX 3090/4090: 8.6
+# - RTX 4000 series Ada: 8.9

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,11 @@ ENV HF_HOME=/model-cache
 
 ENV HF_HUB_OFFLINE=1
 
+# Set CUDA architecture for NVIDIA T4 GPUs (used in Google Cloud Run)
+# This reduces compilation time by avoiding compilation for all GPU architectures
+# Compute capability 7.5 corresponds to NVIDIA T4
+ENV TORCH_CUDA_ARCH_LIST="7.5"
+
 # Fix for c10d warning: "The hostname of the client socket cannot be retrieved."
 # This occurs in container environments where reverse DNS lookup for the container's IP fails.
 # Adding the container's hostname to /etc/hosts pointing to localhost resolves this.


### PR DESCRIPTION
Sets `TORCH_CUDA_ARCH_LIST=7.5` for Google Cloud Run's NVIDIA T4 GPUs to reduce compilation time during startup.

## Changes
- Add `ENV TORCH_CUDA_ARCH_LIST="7.5"` to Dockerfile
- Create .env.example with comprehensive documentation
- Includes notes explaining the setting is for Cloud Run's T4 GPUs

Fixes #16

Generated with [Claude Code](https://claude.ai/code)